### PR TITLE
build: change php version to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.1",
+        "php": "^7.4",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.5",
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Alterar a versão do PHP, no `composer.json`, pra 7.4.

Acredito que sem querer ficou 7.1, porquê o código já tem coisas no 7.4, como a definição dos tipos de propriedades, como:
```
private OAuth2 $client;
```