### PR TITLE
chore: add .phpunit.result.cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 coverage
 .DS_Store
 .env
+/.phpunit.result.cache


### PR DESCRIPTION
Ignorar o arquivo `.phpunit.result.cache` do git. Ou seja, modificações no mesmo não serão detectadas pelo git. 